### PR TITLE
feat: remove noqa comments and add flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ app.add_middleware(
 async def search(request: Request):
     terms = await request.json()
 
-    return StreamingResponse(search_images(terms), media_type="text/plain")  # noqa: E501
+    return StreamingResponse(search_images(terms), media_type="text/plain")
 
 
 @app.post('/train-model/{id}')
@@ -36,7 +36,7 @@ async def train(id: str):
 
 
 @app.post('/predict')
-async def predict(model: UploadFile = File(...), image: UploadFile = File(...)):  # noqa: E501
+async def predict(model: UploadFile = File(...), image: UploadFile = File(...)):
     categories = predict_image(model, image)
 
     return categories

--- a/infer.py
+++ b/infer.py
@@ -1,5 +1,5 @@
 import os
-from fastai.vision.all import load_learner, PILImage, resize_images, Path  # type: ignore  # noqa: E501
+from fastai.vision.all import load_learner, PILImage, resize_images, Path  # type: ignore
 
 
 def main() -> None:
@@ -14,7 +14,7 @@ def main() -> None:
 
     learn_inf = load_learner('./model/model.pkl')
 
-    most_likely_breed,  most_likely_index,  probs = learn_inf.predict(PILImage.create(dest))  # noqa: E501
+    most_likely_breed,  most_likely_index,  probs = learn_inf.predict(PILImage.create(dest))
     print(f"This is probably a: {most_likely_breed}.")
 
     available_breeds = learn_inf.dls.vocab
@@ -27,7 +27,7 @@ def main() -> None:
             probabilities.append(prob)
         count += 1
 
-    ten_most_likely: list[tuple[str, float]] = [(available_breeds[most_likely_index], probs[most_likely_index])]  # noqa: E501
+    ten_most_likely: list[tuple[str, float]] = [(available_breeds[most_likely_index], probs[most_likely_index])]
 
     for i in range(9):
         prob = max(probabilities)

--- a/load_images.py
+++ b/load_images.py
@@ -1,6 +1,6 @@
 from duckduckgo_search import DDGS
 from fastcore.all import L  # type: ignore
-from fastai.vision.all import Path, download_images, resize_images, verify_images, get_image_files  # type: ignore # noqa: E501
+from fastai.vision.all import Path, download_images, resize_images, verify_images, get_image_files  # type: ignore
 from time import sleep
 import json
 from concurrent.futures import ThreadPoolExecutor

--- a/services/images.py
+++ b/services/images.py
@@ -1,6 +1,6 @@
 from duckduckgo_search import DDGS
 from fastcore.all import L  # type: ignore
-from fastai.vision.all import Path, download_images, resize_images, get_image_files, verify_images  # type: ignore # noqa: E501
+from fastai.vision.all import Path, download_images, resize_images, get_image_files, verify_images  # type: ignore
 from time import sleep
 from concurrent.futures import ThreadPoolExecutor
 from uuid import uuid4
@@ -12,7 +12,7 @@ ddgs = DDGS()
 def search_unique(term: str, path):
     dest = (path/term)
     dest.mkdir(exist_ok=True, parents=True)
-    download_images(dest, urls=L(ddgs.images(f'{term} photos', max_results=50)).itemgot('image'))  # noqa: E501
+    download_images(dest, urls=L(ddgs.images(f'{term} photos', max_results=50)).itemgot('image'))
     sleep(.1)
     resize_images(path/term, max_size=400, dest=path/term)
     failed = verify_images(get_image_files(dest))

--- a/services/model.py
+++ b/services/model.py
@@ -23,7 +23,7 @@ def train_model(pathId: str):
 
     data_loaders = data_blocks.dataloaders(path)
 
-    learn = vision_learner(data_loaders, resnet18, metrics=error_rate)  # noqa: E501
+    learn = vision_learner(data_loaders, resnet18, metrics=error_rate)
     learn.fine_tune(3)
 
     shutil.rmtree(f'./images/{pathId}')
@@ -37,10 +37,6 @@ def train_model(pathId: str):
         yield from file
 
     os.remove(f'./models/{pathId}.pkl')
-
-
-def sortCallback(element: tuple[str, Tensor]):
-    return element[1]
 
 
 def predict_image(model: UploadFile = File(...), image: UploadFile = File(...)):  # noqa: E501
@@ -84,7 +80,7 @@ def predict_image(model: UploadFile = File(...), image: UploadFile = File(...)):
 
         categories.append((category, probabilities[i]))
 
-    categories.sort(reverse=True, key=sortCallback)
+    categories.sort(reverse=True, key=(lambda element: element[1].item()))
 
     shutil.rmtree(f'./predictions/{id}')
 

--- a/train.py
+++ b/train.py
@@ -25,7 +25,7 @@ def main() -> None:
 
     data_loaders = data_blocks.dataloaders(path)
 
-    learn = vision_learner(data_loaders, 'convnext_tiny_in22k', metrics=error_rate)  # noqa: E501
+    learn = vision_learner(data_loaders, 'convnext_tiny_in22k', metrics=error_rate)
     learn.fine_tune(3)
 
     interp = ClassificationInterpretation.from_learner(learn)


### PR DESCRIPTION
- Remove noqa comments in lines with less than 120 characters. 
- Add Flake8 config to change max line length to 120 characters.
- Refactor sort categories callback to use lambda function.